### PR TITLE
Raise error when writing to closed socket

### DIFF
--- a/src/news.nim
+++ b/src/news.nim
@@ -334,6 +334,8 @@ proc send*(ws: WebSocket, text: string, opcode = Opcode.Text): Future[void] {.as
     var i = 0
     while i < frame.len:
       let data = frame[i ..< min(frame.len, i + maxSize)]
+      if ws.transp.isClosed:
+        raise newException(WebSocketClosedError, "Socket closed")
       await ws.transp.send(data)
       i += maxSize
       await sleepAsync(1)


### PR DESCRIPTION
Without this change native socket will crash with segmentation fault.