### PR TITLE
Fixed logic error when adding protocol response header

### DIFF
--- a/src/news.nim
+++ b/src/news.nim
@@ -127,7 +127,7 @@ when not newsUseChronos:
     response.add("Sec-WebSocket-Accept: " & acceptKey & CRLF)
     response.add("Connection: Upgrade" & CRLF)
     response.add("Upgrade: websocket" & CRLF)
-    if not ws.protocol.len == 0:
+    if ws.protocol.len > 0:
       response.add("Sec-WebSocket-Protocol: " & ws.protocol & CRLF)
     response.add CRLF
 


### PR DESCRIPTION
`if not ws.protocol.len == 0` doesn't do what it looks like, since `not` has higher precedence than `==`.

This caused the `Sec-WebSocket-Protocol` header to never be added.