### PR TITLE
fix secKey encoding

### DIFF
--- a/src/news.nim
+++ b/src/news.nim
@@ -261,14 +261,16 @@ proc newWebSocket*(url: string, headers: StringTableRef = nil,
       urlPath.add("?" & uri.query)
     if urlPath.len == 0:
       urlPath = "/"
-    let secKey = encode($genOid())[16..^1]
+    let
+      secKey = ($genOid())[^16..^1]
+      secKeyEncoded = encode(secKey)
     let requestLine = &"GET {urlPath} HTTP/1.1"
     let predefinedHeaders = [
       &"Host: {uri.hostname}:{$port}",
       "Connection: Upgrade",
       "Upgrade: websocket",
       "Sec-WebSocket-Version: 13",
-      &"Sec-WebSocket-Key: {secKey}"
+      &"Sec-WebSocket-Key: {secKeyEncoded}"
     ]
 
     var customHeaders = ""
@@ -286,7 +288,7 @@ proc newWebSocket*(url: string, headers: StringTableRef = nil,
     while not output.endsWith(static(CRLF & CRLF)):
       output.add await ws.transp.recv(1)
 
-    let error = validateServerResponse(output, secKey)
+    let error = validateServerResponse(output, secKeyEncoded)
     if error.len > 0:
       raise newException(WebSocketError, "WebSocket connection error: " & error)
 


### PR DESCRIPTION
The secKey was not correctly generated:
```
The request MUST include a header field with the name
|Sec-WebSocket-Key|. The value of this header field MUST be a
nonce consisting of a randomly selected 16-byte value that has
been base64-encoded (see Section 4 of [RFC4648]). The nonce
MUST be selected randomly for each connection.
```

The current implementation is wrong on two ways:
- The base64 encoding is done _before_ trimming to 16 bytes
- The the trimming to 16 bytes was not correct: `[16..^1]` can be any size

(https://github.com/NethermindEth/nethermind/issues/3256#issuecomment-887917338 for more background)