### PR TITLE
Fix: Accidentally throttling to no more than 1000 messages/sec

### DIFF
--- a/src/news.nim
+++ b/src/news.nim
@@ -426,12 +426,13 @@ proc doSend(ws: WebSocket, text: string, opcode: Opcode): Future[void] {.async.}
     # with really large packets
     var i = 0
     while i < frame.len:
+      if i > 0:
+        await sleepAsync(1)
       let data = frame[i ..< min(frame.len, i + maxSize)]
       if ws.transp.isClosed:
         raise newException(WebSocketClosedError, "Socket closed")
       await ws.transp.send(data)
       i += maxSize
-      await sleepAsync(1)
   except CatchableError as e:
     if ws.transp.isClosed:
       ws.readyState = Closed


### PR DESCRIPTION
The loop in doSend is intended to pause 1ms in between 1MB chunks of a very large frame. But it pauses even on small frames. This introduces a 1ms delay after every send, effectively throttling connections to no more than 1000 messages/second.

I simply changed the logic to sleep 1ms before every chunk *after the first*. This change literally doubled the throughput of a client I'm working on.

>(The hilarious thing is that when I went to fork the repo and create this PR I discovered that (a) I already had a fork of `news`, and (b) that fork contains a commit from 2020 that makes exactly this change on top of v0.5. I guess I had just neglected to create a PR the last time I was working on a WebSocket project in Nim … and then two+ years later I forgot I’d already fixed this! 🤣 )

Fixes #24